### PR TITLE
Fix issue with separators between hiscore and xp favorites.

### DIFF
--- a/src/app/features/hiscores/components/search-hiscore/search-hiscore.component.html
+++ b/src/app/features/hiscores/components/search-hiscore/search-hiscore.component.html
@@ -30,7 +30,7 @@
 </ion-card>
 
 <ion-card *ngIf="favorites && favoriteHiscores?.length > 0">
-  <ion-list>
+  <ion-list lines="full">
     <ion-list-header no-margin color="secondary">
       <ion-label>Favorites</ion-label>
     </ion-list-header>
@@ -39,7 +39,7 @@
 </ion-card>
 
 <ion-card *ngIf="recents && recentHiscores?.length > 0">
-  <ion-list>
+  <ion-list lines="full">
     <ion-list-header no-margin color="secondary">
       <ion-label>Recent</ion-label>
     </ion-list-header>

--- a/src/app/features/xp-tracker/components/search-xp/search-xp.component.html
+++ b/src/app/features/xp-tracker/components/search-xp/search-xp.component.html
@@ -16,7 +16,7 @@
 </ion-card>
 
 <ion-card *ngIf="favorites && favoriteXp?.length > 0">
-  <ion-list>
+  <ion-list lines="full">
     <ion-list-header no-margin color="secondary">
       <ion-label>Favorites</ion-label>
     </ion-list-header>
@@ -25,7 +25,7 @@
 </ion-card>
 
 <ion-card *ngIf="recents && recentXp?.length > 0">
-  <ion-list>
+  <ion-list lines="full">
     <ion-list-header no-margin color="secondary">
       <ion-label>Recent</ion-label>
     </ion-list-header>


### PR DESCRIPTION
Fixes #34.
 
Ion-lists were missing `lines="full"` properties.